### PR TITLE
add help text to each input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3322,12 +3322,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3348,7 +3350,8 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -3499,6 +3502,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3506,12 +3510,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3530,6 +3536,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3709,7 +3716,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3815,7 +3823,8 @@
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/Abstract.vue
+++ b/src/Abstract.vue
@@ -10,6 +10,10 @@
                 remove
             </button>
         </p>
+        <HelpText
+            text="A description of the software (version)"
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#software-citation-metadata-required"
+        />
         <textarea
             v-bind:class="{error: validation.error }"
             v-bind:value="abstract"
@@ -35,6 +39,8 @@
 
 <script>
 
+import HelpText from './HelpText.vue';
+
 import {add,
         remove,
         update} from './AbstractEmitters.js';
@@ -44,6 +50,7 @@ import {validate} from './AbstractValidators.js';
 export default {
     name: 'Abstract',
     components: {
+        HelpText
     },
     props: {
         abstract: String

--- a/src/Affiliation.vue
+++ b/src/Affiliation.vue
@@ -10,6 +10,10 @@
                 remove
             </button>
         </p>
+        <HelpText
+            text="To specify the affiliation of a person, e.g., a university, research centre, etc."
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#exemplary-uses-2"
+        />
         <input
             v-bind:class="{error: validation.error }"
             v-bind:value="affiliation"
@@ -37,6 +41,8 @@
 
 <script>
 
+import HelpText from './HelpText.vue';
+
 import {add,
         remove,
         update} from './AffiliationEmitters.js';
@@ -46,6 +52,7 @@ import {validate} from './AffiliationValidators.js';
 export default {
     name: 'Affiliation',
     components: {
+        HelpText
     },
     props: {
         affiliation: String

--- a/src/Author.vue
+++ b/src/Author.vue
@@ -49,6 +49,10 @@
                 <p class="caption">
                     given-names
                 </p>
+                <HelpText
+                    text="Specify given and any other names."
+                    url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#exemplary-uses-2"
+                />
                 <input
                     v-bind:value="author.given_names"
                     v-on:input="update_given_names($event)"
@@ -66,6 +70,10 @@
                 <p class="caption">
                     family-names
                 </p>
+                <HelpText
+                    text="Specify family names, including combinations of given and patronymic forms."
+                    url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#exemplary-uses-2"
+                />
                 <input
                     v-bind:value="author.family_names"
                     v-on:input="update_family_names($event)"
@@ -94,6 +102,7 @@
 
 import Affiliation from './Affiliation.vue';
 import AuthorOrcid from './Orcid.vue';
+import HelpText from './HelpText.vue';
 import NameParticle from './NameParticle.vue';
 import NameSuffix from './NameSuffix.vue';
 
@@ -120,6 +129,7 @@ export default {
     components: {
         Affiliation,
         AuthorOrcid,
+        HelpText,
         NameParticle,
         NameSuffix
     },

--- a/src/Authors.vue
+++ b/src/Authors.vue
@@ -12,6 +12,10 @@
                 </div>
             </button>
         </p>
+        <HelpText
+            text="The author(s) of the software"
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#software-citation-metadata-required"
+        />
         <ul class="authors">
             <Author
                 v-for="author in authors"
@@ -60,11 +64,13 @@ import {add,
         update_orcid} from './AuthorsEmitters.js';
 
 import Author from './Author.vue';
+import HelpText from './HelpText.vue';
 
 export default {
     name: 'Authors',
     components: {
-        Author
+        Author,
+        HelpText
     },
     props: {
         authors: Array

--- a/src/DateReleased.vue
+++ b/src/DateReleased.vue
@@ -14,6 +14,11 @@
                 remove
             </button>
         </p>
+        <HelpText
+            v-show="has_date_released"
+            text="The release date of the software version."
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#software-citation-metadata-required"
+        />
         <button
             v-show="!has_date_released"
             tabindex="-1"
@@ -47,9 +52,12 @@ import {add,
 
 import {validate} from './DateReleasedValidators.js';
 
+import HelpText from './HelpText.vue';
+
 export default {
     name: 'DateReleased',
     components: {
+        HelpText
     },
     props: {
         date_released: String

--- a/src/Doi.vue
+++ b/src/Doi.vue
@@ -14,6 +14,11 @@
                 remove
             </button>
         </p>
+        <HelpText
+            v-show="has_doi"
+            text="The DOI of the work (not the resolver URL, i.e., 10.5281/zenodo.1003150, not http://doi.org/10.5281/zenodo.1003150)"
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#software-citation-metadata-required"
+        />
         <button
             v-show="!has_doi"
             tabindex="-1"
@@ -47,9 +52,12 @@ import {add,
 
 import {validate} from './DoiValidators.js';
 
+import HelpText from './HelpText.vue';
+
 export default {
     name: 'Doi',
     components: {
+        HelpText
     },
     props: {
         doi: String

--- a/src/Form.vue
+++ b/src/Form.vue
@@ -6,6 +6,10 @@
                 <p class="caption">
                     cff-version
                 </p>
+                <HelpText
+                    text="The exact version of the Citation File Format that is used for the file."
+                    url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#cff-version-required"
+                />
                 <input
                     v-bind:class="{error: cff_version_validation.error }"
                     v-bind:value="cff_version"
@@ -25,6 +29,10 @@
                 <p class="caption">
                     message
                 </p>
+                <HelpText
+                    text="Specify instructions to users on how to cite the software the CITATION.cff file is associated with."
+                    url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#message-required"
+                />
                 <textarea
                     v-bind:class="{error: message_validation.error }"
                     v-bind:value="message"
@@ -124,6 +132,7 @@
 
 <script>
 import CreativeWork from './CreativeWork.vue';
+import HelpText from './HelpText.vue';
 
 import {add_abstract,
         add_affiliation,
@@ -188,7 +197,8 @@ import {validate_message,
 export default {
     name: 'Form',
     components: {
-        CreativeWork
+        CreativeWork,
+        HelpText
     },
     props: {
         abstract: String,

--- a/src/HelpText.vue
+++ b/src/HelpText.vue
@@ -1,0 +1,36 @@
+<template>
+    <p class="help-text">
+        {{text}}
+        <a class="spec-link" target="docs" v-bind:href="url">(spec)</a>
+    </p>
+</template>
+
+<script>
+
+export default {
+    name: 'HelpText',
+    components: {
+    },
+    props: {
+        text: String,
+        url: String
+    },
+    computed: {
+    },
+    methods: {
+    }
+};
+
+</script>
+
+<style>
+    p.help-text {
+        font-style: italic;
+        font-size: 0.8rem;
+        margin-top: 0;
+        margin-bottom: 0.5em;
+    }
+    a.spec-link {
+        font-style: normal;
+    }
+</style>

--- a/src/Identifier.vue
+++ b/src/Identifier.vue
@@ -36,6 +36,10 @@
         <p class="caption">
             type
         </p>
+        <HelpText
+            text="The type of the identifier."
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#identifier-type-strings"
+        />
         <input
             v-bind:value="identifier.type"
             v-bind:class="{error: validation_type.error }"
@@ -75,8 +79,13 @@ import {move_identifier_down,
 import {validate_type,
         validate_value} from './IdentifierValidators.js';
 
+import HelpText from './HelpText.vue';
+
 export default {
     name: 'Identifier',
+    components: {
+        HelpText
+    },
     props: {
         identifier: Object
     },

--- a/src/Identifiers.vue
+++ b/src/Identifiers.vue
@@ -19,6 +19,10 @@
                 </div>
             </button>
         </p>
+        <HelpText
+            text="Persistent identifiers for the software."
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#identifier-objects"
+        />
         <ul>
             <Identifier
                 v-for="identifier in identifiers"
@@ -54,11 +58,13 @@ import {add_identifier,
         update_identifier_type,
         update_identifier_value} from './IdentifiersEmitters.js';
 
+import HelpText from './HelpText.vue';
 import Identifier from './Identifier.vue';
 
 export default {
     name: 'Identifiers',
     components: {
+        HelpText,
         Identifier
     },
     props: {

--- a/src/Keywords.vue
+++ b/src/Keywords.vue
@@ -19,6 +19,10 @@
                 </div>
             </button>
         </p>
+        <HelpText
+            text="Keywords pertaining to the software version"
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#software-citation-metadata-required"
+        />
         <ul>
             <Keyword
                 v-for="keyword in keywords"
@@ -52,11 +56,13 @@ import {add_keyword,
         remove_keywords,
         update_keyword} from './KeywordsEmitters.js';
 
+import HelpText from './HelpText.vue';
 import Keyword from './Keyword.vue';
 
 export default {
     name: 'Keywords',
     components: {
+        HelpText,
         Keyword
     },
     props: {

--- a/src/License.vue
+++ b/src/License.vue
@@ -14,6 +14,11 @@
                 remove
             </button>
         </p>
+        <HelpText
+            v-show="has_license"
+            text="The license the software version is licensed under."
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#software-citation-metadata-required"
+        />
         <button
             v-show="!has_license"
             tabindex="-1"
@@ -47,9 +52,12 @@ import {add,
 
 import {validate_license} from './LicenseValidators.js';
 
+import HelpText from './HelpText.vue';
+
 export default {
     name: 'License',
     components: {
+        HelpText
     },
     props: {
         license: String

--- a/src/NameParticle.vue
+++ b/src/NameParticle.vue
@@ -10,6 +10,10 @@
                 remove
             </button>
         </p>
+        <HelpText
+            text="Specify nobiliary particles and prepositions, such as in Ludwig van Beethoven or Rafael van der Vaart."
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#exemplary-uses-2"
+        />
         <input
             v-bind:class="{error: validation.error }"
             v-bind:value="name_particle"
@@ -42,9 +46,12 @@ import {add,
 
 import {validate} from './NameParticleValidators.js';
 
+import HelpText from './HelpText.vue';
+
 export default {
     name: 'NameParticle',
     components: {
+        HelpText
     },
     props: {
         name_particle: String

--- a/src/NameSuffix.vue
+++ b/src/NameSuffix.vue
@@ -10,6 +10,10 @@
                 remove
             </button>
         </p>
+        <HelpText
+            text="Specify suffixes such as Jr. or III."
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#exemplary-uses-2"
+        />
         <input
             v-bind:class="{error: validation.error }"
             v-bind:value="name_suffix"
@@ -42,9 +46,12 @@ import {add,
 
 import {validate} from './NameSuffixValidators.js';
 
+import HelpText from './HelpText.vue';
+
 export default {
     name: 'NameSuffix',
     components: {
+        HelpText
     },
     props: {
         name_suffix: String

--- a/src/Orcid.vue
+++ b/src/Orcid.vue
@@ -10,6 +10,10 @@
                 remove
             </button>
         </p>
+        <HelpText
+            text="The person's ORCID iD."
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#exemplary-uses-1"
+        />
         <input
             v-bind:value="orcid"
             v-bind:class="{error: validation.error }"
@@ -39,8 +43,13 @@ import {add,
 
 import {validate} from './OrcidValidators.js';
 
+import HelpText from './HelpText.vue';
+
 export default {
     name: 'Orcid',
+    components: {
+        HelpText
+    },
     props: {
         orcid: String
     },

--- a/src/RepositoryCode.vue
+++ b/src/RepositoryCode.vue
@@ -14,6 +14,11 @@
                 remove
             </button>
         </p>
+        <HelpText
+            v-show="has_repository_code"
+            text="The URL to the software version in a source code repository."
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#software-citation-metadata-required"
+        />
         <button
             v-show="!has_repository_code"
             tabindex="-1"
@@ -46,9 +51,12 @@ import {add,
 
 import {validate} from './RepositoryCodeValidators.js';
 
+import HelpText from './HelpText.vue';
+
 export default {
     name: 'RepositoryCode',
     components: {
+        HelpText
     },
     props: {
         repository_code: String

--- a/src/Title.vue
+++ b/src/Title.vue
@@ -13,6 +13,11 @@
             >remove
             </button>
         </p>
+        <HelpText
+            v-show="has_title"
+            text="The name of the software (may include a specific name for the software version)"
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#software-citation-metadata-required"
+        />
         <button
             v-show="!has_title"
             tabindex="-1"
@@ -35,9 +40,12 @@ import {add,
         remove,
         update} from './TitleEmitters.js';
 
+import HelpText from './HelpText.vue';
+
 export default {
     name: 'Title',
     components: {
+        HelpText
     },
     props: {
         title: String

--- a/src/Version.vue
+++ b/src/Version.vue
@@ -14,6 +14,11 @@
                 remove
             </button>
         </p>
+        <HelpText
+            v-show="has_version"
+            text="The version of the software."
+            url="https://github.com/citation-file-format/citation-file-format/blob/main/README.md#software-citation-metadata-required"
+        />
         <button
             v-show="!has_version"
             tabindex="-1"
@@ -38,8 +43,13 @@ import {add,
         remove,
         update} from './VersionEmitters.js';
 
+import HelpText from './HelpText.vue';
+
 export default {
     name: 'Version',
+    components: {
+        HelpText
+    },
     props: {
         version: String
     },


### PR DESCRIPTION
Thanks for making this tool! I used it this morning, but I needed to keep cross-referencing with the spec to work out what some fields were for.

This adds a line describing what each field is for, just below the caption line. There's also a link to the corresponding part of the spec.

The help text is drawn from the CFF specification at https://github.com/citation-file-format/citation-file-format/blob/main/README.md#entity-objects.

fixes #5